### PR TITLE
MatchFirst shuld return ParseResults similar as what the element been…

### DIFF
--- a/src/pyparsing.py
+++ b/src/pyparsing.py
@@ -3477,6 +3477,14 @@ class Or(ParseExpression):
         else:
             raise ParseException(instring, loc, "no defined alternatives to match", self)
 
+    def setResultsName(self, name, listAllMatches=False):
+        # Instead of defining a result name for this element, we give a name to each element.
+        newself = self.copy()
+        newself.exprs = [
+            e.setResultsName(name, listAllMatches=listAllMatches)
+            for e in newself.exprs
+        ]
+        return newself
 
     def __ixor__(self, other ):
         if isinstance( other, basestring ):
@@ -3545,6 +3553,15 @@ class MatchFirst(ParseExpression):
                 raise maxException
             else:
                 raise ParseException(instring, loc, "no defined alternatives to match", self)
+
+    def setResultsName(self, name, listAllMatches=False):
+        # Instead of defining a result name for this element, we give a name to each element.
+        newself = self.copy()
+        newself.exprs = [
+            e.setResultsName(name, listAllMatches=listAllMatches)
+            for e in newself.exprs
+        ]
+        return newself
 
     def __ior__(self, other ):
         if isinstance( other, basestring ):

--- a/src/unitTests.py
+++ b/src/unitTests.py
@@ -1499,6 +1499,26 @@ class ParseResultsPickleTest(ParseTestCase):
             assert newresult.dump() == result.dump(), "failed to pickle/unpickle ParseResults: expected %r, got %r" % (result, newresult)
 
 
+class ParseResultsWithNameMatchFirst(ParseTestCase):
+    def runTest(self):
+        from pyparsing import Literal
+        expr_a = Literal('not') + Literal('the') + Literal('bird')
+        expr_b = Literal('the') + Literal('bird')
+
+        expr = (expr_a | expr_b).setResultsName('rexp')
+        assert list(expr.parseString('not the bird')['rexp']) == 'not the bird'.split()
+        assert list(expr.parseString('the bird')['rexp']) == 'the bird'.split()
+
+
+class ParseResultsWithNameOr(ParseTestCase):
+    def runTest(self):
+        from pyparsing import Literal
+        expr_a = Literal('not') + Literal('the') + Literal('bird')
+        expr_b = Literal('the') + Literal('bird')
+
+        expr = (expr_a ^ expr_b).setResultsName('rexp')
+        assert list(expr.parseString('not the bird')['rexp']) == 'not the bird'.split()
+        assert list(expr.parseString('the bird')['rexp']) == 'the bird'.split()
 
 class ParseResultsWithNamedTupleTest(ParseTestCase):
     def runTest(self):


### PR DESCRIPTION
… match should return

I think this is a bug, but it may be intended behaivure, just dont seems right o me (by the way love pyparsing!!!).

concider `opt1` and `opt2`, defined as follow:

```
from pyparsing import Literal, pyparsing_common

ipv6 = (Literal('[') + pyparsing_common.ipv6_address + Literal(']'))
ipv4 = pyparsing_common.ipv4_address

opt1 = ipv6.setResultsName('ip')
opt2 = (ipv4 | ipv6).setResultsName('ip')

print(opt1.parseString('[::1]').get('ip'))
print(opt2.parseString('[::1]').get('ip'))
```

Both cases should print the same statement but they print similar statements but the outpur of this is:

```
['[', '::1', ']']
[
```

The answer to this is simple, `opt1.saveAsList == True` but `opt2.saveAsList == False`, so when building the `ParseResults` after the element has been match, only the first element of ipv6 is selected given a name.

I know that if i use `Combine(ipv6)` when declaring `opt2` and it should be enought, i also know that i could alays change `MatchFirst.saveAsList`, but seems like a extra step for something that seems intuitive from the syntax, match `ipv4` or `ipv6` and then name that result as IP.